### PR TITLE
Fix three code bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
   // Get country (simplified)
   async function getCountry() {
     try {
-      const response = await fetch('https://ipapi.co/json ');
+      const response = await fetch('https://ipapi.co/json');
       const data = await response.json();
       return data.country_name || 'Unknown';
     } catch (error) {

--- a/netlify/function/forgot-password.js
+++ b/netlify/function/forgot-password.js
@@ -217,11 +217,21 @@ exports.handler = async (event, context) => {
     };
 
     // 7. Send the email via Brevo API
+    const BREVO_API_KEY = process.env.BREVO_API_KEY;
+    
+    if (!BREVO_API_KEY) {
+      console.error("BREVO_API_KEY environment variable is not set");
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'Email service is not configured properly' })
+      };
+    }
+    
     const response = await fetch('https://api.brevo.com/v3.1/smtp/email', {
       method: 'POST',
       headers: {
         'accept': 'application/json',
-        'api-key': 'YOUR_REAL_BREVO_API_KEY_HERE', // <-- REPLACE WITH YOUR ACTUAL KEY
+        'api-key': BREVO_API_KEY,
         'content-type': 'application/json'
       },
       body: JSON.stringify(emailData)

--- a/nirobo_spider.py
+++ b/nirobo_spider.py
@@ -36,7 +36,10 @@ class NiroboSpider(scrapy.Spider):
         'nytimes.com'
     ]
 
-    visited_urls = set()
+    def __init__(self, *args, **kwargs):
+        super(NiroboSpider, self).__init__(*args, **kwargs)
+        # Initialize visited_urls as an instance attribute to avoid sharing state between spider instances
+        self.visited_urls = set()
 
     def parse(self, response):
         # Skip if already visited


### PR DESCRIPTION
Fixes a URL typo, externalizes a hardcoded API key, and corrects a mutable class-level default in `nirobo_spider.py`.

The `visited_urls` set was a mutable class-level attribute, causing all spider instances to share the same state, leading to incorrect behavior and potential memory issues across multiple runs.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ee92159-1169-4746-a420-4a4de40e3c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ee92159-1169-4746-a420-4a4de40e3c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

